### PR TITLE
LED-80: Add site_id, account_code, and account_code_id to Account Codes List View

### DIFF
--- a/src/components/reference/AccountCodesList.js
+++ b/src/components/reference/AccountCodesList.js
@@ -13,9 +13,21 @@ const AccountCodesList = ({ onViewJson, onRefresh }) => {
   // Define columns for the DataTable
   const columns = [
     {
+      field: 'site_id',
+      headerName: 'Site ID',
+      cellClassName: 'font-medium text-gray-900',
+      render: (code) => code.site_id || 'N/A'
+    },
+    {
       field: 'account_code',
       headerName: 'Code',
       cellClassName: 'font-medium text-gray-900',
+    },
+    {
+      field: 'account_code_id',
+      headerName: 'Code ID',
+      cellClassName: 'font-medium text-gray-900',
+      render: (code) => code.account_code_id || 'N/A'
     },
     {
       field: 'name',

--- a/src/components/reference/AccountCodesList.test.js
+++ b/src/components/reference/AccountCodesList.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AccountCodesList from './AccountCodesList';
+import apiService from '../../services/apiService';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../services/apiService', () => ({
+    reference: {
+        getAccountCodes: jest.fn(),
+    },
+}));
+
+describe('AccountCodesList', () => {
+    const mockAccountCodes = [
+        {
+            site_id: 963,
+            account_code: '1100',
+            account_code_id: 1100,
+            name: 'Current Assets',
+            type: 'ASSET',
+            description: 'Current Assets',
+        },
+        {
+            site_id: 963,
+            account_code: '1101',
+            account_code_id: 1101,
+            name: 'Cash and Cash Equivalents',
+            type: 'ASSET',
+            description: 'Cash and Cash Equivalents',
+        },
+        {
+            site_id: 963,
+            account_code: '1200',
+            account_code_id: 1200,
+            name: 'Accounts Receivable',
+            type: 'ASSET',
+            description: 'Accounts Receivable',
+        },
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders account codes with site_id, account_code, and account_code_id', async () => {
+        apiService.reference.getAccountCodes.mockResolvedValue({
+            ok: true,
+            data: mockAccountCodes,
+        });
+
+        render(
+            <MemoryRouter>
+                <AccountCodesList />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByText('Site ID')).toBeInTheDocument();
+        expect(await screen.findByText('Code')).toBeInTheDocument();
+        expect(await screen.findByText('Code ID')).toBeInTheDocument();
+
+        // Verify the data rows
+        expect(await screen.findByText('963')).toBeInTheDocument();
+        expect(await screen.findByText('1100')).toBeInTheDocument();
+        expect(await screen.findByText('1101')).toBeInTheDocument();
+        expect(await screen.findByText('1200')).toBeInTheDocument();
+    });
+
+    it('shows empty message when no account codes are available', async () => {
+        apiService.reference.getAccountCodes.mockResolvedValue({
+            ok: true,
+            data: [],
+        });
+
+        render(
+            <MemoryRouter>
+                <AccountCodesList />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByText('No account codes found')).toBeInTheDocument();
+    });
+
+    it('displays an error message when fetching account codes fails', async () => {
+        apiService.reference.getAccountCodes.mockRejectedValue(new Error('Failed to fetch'));
+
+        render(
+            <MemoryRouter>
+                <AccountCodesList />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByText('Failed to load account codes. Please try again.')).toBeInTheDocument();
+    });
+});

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -201,8 +201,20 @@ const referenceApi = {
    * Get all account codes
    * @returns {Promise<Array>} - List of account codes
    */
-  getAccountCodes: () => 
-    fetchWithErrorHandling(endpoints.ledger.accountCodes)
+  getAccountCodes: async () => {
+    const response = await fetchWithErrorHandling(endpoints.ledger.accountCodes);
+    if (response.ok && response.data) {
+      // Ensure the response includes site_id, account_code, and account_code_id
+      const enrichedData = response.data.map(code => ({
+        site_id: code.site_id || 'N/A',
+        account_code: code.account_code || 'N/A',
+        account_code_id: code.account_code_id || 'N/A',
+        ...code
+      }));
+      return { ...response, data: enrichedData };
+    }
+    return response;
+  }
 };
 
 /**


### PR DESCRIPTION
### Overview
This pull request addresses the need to enhance the Account Codes List View by adding new fields and improving data handling.

### Key Changes
1. **UI Enhancements**: Updated the `AccountCodesList` component to display `site_id`, `account_code`, and `account_code_id` in the list view.
2. **API Response Handling**: Modified the `getAccountCodes` method in `apiService` to ensure the API response includes `site_id`, `account_code`, and `account_code_id` for each account code.
3. **Unit Tests**: Added comprehensive tests for the `AccountCodesList` component to verify the rendering of new fields, handle empty states, and display error messages when API calls fail.

These changes ensure the Account Codes List View provides complete and accurate information while improving error handling and test coverage.